### PR TITLE
Monokromt Facebook-ikon

### DIFF
--- a/static-src/customstyle.less
+++ b/static-src/customstyle.less
@@ -27,7 +27,7 @@ body {
   border-radius: 5px;
   width: 1em;
   padding: 0 0.1em;
-  background-color: #3b5998;
+  background-color: #fff;
 
   &:hover {
       background-color: #2d4373;
@@ -36,7 +36,7 @@ body {
   svg {
       width: .8em;
       height: .8em;
-      fill: #fff;
+      fill: #000;
       stroke: none;
   }
 }


### PR DESCRIPTION
Det blå Facebook-ikon skærer i øjene på en ellers farveforladt side. Dette PR giver facebook-ikonet en hvid baggrund og sort forgrund. Eksempel:

![screen shot 2016-09-19 at 10 42 39](https://cloud.githubusercontent.com/assets/879967/18626633/800d89cc-7e56-11e6-8739-854a1b5bc499.png)

Jeg har dog beholdt den mørkeblå farve ved hover:

![screen shot 2016-09-19 at 10 42 51](https://cloud.githubusercontent.com/assets/879967/18626645/914d1496-7e56-11e6-9a86-4d7812521238.png)

---
PS. Ikke relateret til dette PR, men det kunne måske give mening at flytte ikonet til en skjult kollonne _før_ teksten, for at undgå at ikonerne "støjer" for meget i layoutet. Eksempel:

![screen shot 2016-09-19 at 10 55 15](https://cloud.githubusercontent.com/assets/879967/18626831/a1cd7ef4-7e57-11e6-914a-d36428af73f0.png)
