### PR TITLE
Add "context gfyear" to Title

### DIFF
--- a/tkweb/apps/idm/models.py
+++ b/tkweb/apps/idm/models.py
@@ -236,9 +236,18 @@ class Title(models.Model):
     root = models.CharField(max_length=10, verbose_name='Titel')
     kind = models.CharField(max_length=10, choices=KIND, verbose_name='Slags')
 
+    def set_context_gfyear(self, gfyear):
+        self._context_gfyear = gfyear
+
+    def get_context_gfyear(self):
+        try:
+            return self._context_gfyear
+        except AttributeError:
+            return config.GFYEAR
+
     def age(self, gfyear=None):
         if gfyear is None:
-            gfyear = config.GFYEAR
+            gfyear = self.get_context_gfyear()
         return gfyear - self.period
 
     def display_root(self):


### PR DESCRIPTION
When historical data should be displayed in a Django template, displayed titles should match the historical data. In this case, the view code can prepare the titles with a locally defined context gfyear which will be used instead of the current gfyear.

Dette er nyttigt i INKA-systemet der har en funktion til at hente en liste over folk der var på krydslisten på et bestemt tidspunkt, da denne funktion på passende vis kan sætte context gfyear -- så behøver alle views der bruger denne funktion ikke bekymre sig om at modificere display_title på alle titler.

Hvad synes du @neic ? Et alternativ ville være at gøre display_title til et template tag der kunne bestemme gfyear ud fra en variabel eller request context (eftersom man [ikke kan give argumenter til Python-funktioner i en Django template](http://stackoverflow.com/q/1529550/1570972)).