### PR TITLE
Replace notPublic with BaseMedia.visibility; add EditVisibilityForm

### DIFF
--- a/import-gallery.py
+++ b/import-gallery.py
@@ -384,10 +384,10 @@ for yearFolder in os.listdir(rootdir):
                         continue
 
                     if os.path.basename(filepath) in missingFromResized:
-                        instance.notPublic = True
+                        instance.visibility = BaseMedia.DISCARDED
 
                     if os.path.basename(filepath) in notPublicFiles:
-                        instance.notPublic = True
+                        instance.visibility = BaseMedia.DISCARDED
 
                     instance.forcedOrder = i
                     i += 1

--- a/tkweb/apps/gallery/admin.py
+++ b/tkweb/apps/gallery/admin.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib import admin
 from django.db import models
 from tkweb.apps.gallery.models import Album, BaseMedia
+from django.core.urlresolvers import reverse
 
 
 class InlineBaseMediaAdmin(admin.TabularInline):
@@ -30,7 +31,7 @@ class AlbumAdminForm(forms.ModelForm):
 
 class AlbumAdmin(admin.ModelAdmin):
     # List display of multiple albums
-    list_display = ('title', 'gfyear', 'publish_date',)
+    list_display = ('title', 'gfyear', 'publish_date', 'get_visibility_link')
     ordering = ['-gfyear', 'eventalbum', '-oldFolder', '-publish_date'] # Reverse of models.Album.ordering
     list_filter = ('gfyear', 'eventalbum')
 
@@ -49,6 +50,17 @@ class AlbumAdmin(admin.ModelAdmin):
             # When creating Album, don't display the BaseMedia inlines
             return []
         return super(AlbumAdmin, self).get_inline_instances(request, obj)
+
+    def get_visibility_link(self, album):
+        file = album.basemedia.first()
+        if file:
+            kwargs = dict(gfyear=album.gfyear, album_slug=album.slug,
+                          image_slug=file.slug)
+            return format_html(
+                '<a href="{}?v=1">Udvælg billeder</a>',
+                reverse('image', kwargs=kwargs))
+
+    get_email.short_description = 'Udvælg billeder'
 
 
 admin.site.register(Album, AlbumAdmin)

--- a/tkweb/apps/gallery/admin.py
+++ b/tkweb/apps/gallery/admin.py
@@ -9,7 +9,7 @@ from tkweb.apps.gallery.models import Album, BaseMedia
 class InlineBaseMediaAdmin(admin.TabularInline):
     model = BaseMedia
     extra = 0
-    fields = ( 'admin_thumbnail', 'date', 'caption', 'notPublic', 'slug', 'forcedOrder', 'isCoverFile',)
+    fields = ( 'admin_thumbnail', 'date', 'caption', 'visibility', 'slug', 'forcedOrder', 'isCoverFile',)
     readonly_fields = ( 'admin_thumbnail', 'slug', 'isCoverFile',)
 
     def has_add_permission(self, request):

--- a/tkweb/apps/gallery/forms.py
+++ b/tkweb/apps/gallery/forms.py
@@ -1,0 +1,48 @@
+# encoding: utf8
+from __future__ import absolute_import, unicode_literals, division
+
+import re
+from django import forms
+from tkweb.apps.gallery.models import BaseMedia
+
+
+class EditVisibilityForm(forms.Form):
+    class Missing(Exception):
+        pass
+
+    def __init__(self, file_visibility, **kwargs):
+        super(EditVisibilityForm, self).__init__(**kwargs)
+        self.basemedias = []
+        self.album_pks = set()
+        for file in file_visibility:
+            if isinstance(file, BaseMedia):
+                pk = file.pk
+                visibility = file.visibility
+                album = file.album_id
+            elif isinstance(file, tuple):
+                pk, visibility, album = file
+            else:
+                raise TypeError(type(file))
+            k = 'i%s' % pk
+            self.album_pks.add(album)
+            self.fields[k] = forms.ChoiceField(
+                choices=BaseMedia.VISIBILITY,
+                initial=visibility,
+                widget=forms.RadioSelect)
+            self.basemedias.append((pk, k))
+
+    @classmethod
+    def from_POST(cls, post_data):
+        pattern = r'^i(\d+)$'
+        pks = []
+        for k, v in post_data.items():
+            mo = re.match(pattern, k)
+            if mo:
+                pks.append(int(mo.group(1)))
+        files = BaseMedia.objects.filter(pk__in=pks)
+        files = list(files.values_list('pk', 'visibility', 'album_id'))
+        found_pks = [f[0] for f in files]
+        missing = set(pks) - set(found_pks)
+        if missing:
+            raise cls.Missing('Not found: %r' % (sorted(missing),))
+        return cls(files, data=post_data)

--- a/tkweb/apps/gallery/migrations/0009_basemedia_visibility.py
+++ b/tkweb/apps/gallery/migrations/0009_basemedia_visibility.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gallery', '0008_auto_20160917_2233'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='basemedia',
+            name='visibility',
+            field=models.CharField(verbose_name='Synlighed', max_length=10, default='new', choices=[('public', 'Synligt'), ('discarded', 'Skjult (fravalgt)'), ('sensitive', 'Skjult (personfølsomt)'), ('new', 'Ubesluttet')]),
+        ),
+    ]

--- a/tkweb/apps/gallery/migrations/0010_set_visibility.py
+++ b/tkweb/apps/gallery/migrations/0010_set_visibility.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def set_visibility(apps, schema_editor):
+    BaseMedia = apps.get_model('gallery', 'BaseMedia')
+    # Note: We cannot access BaseMedia.DISCARDED and PUBLIC constants here
+    # since 'BaseMedia' is a Django-synthesized migration model
+    # and not the real models.BaseMedia class definition.
+    BaseMedia.objects.filter(notPublic=True).update(visibility='discarded')
+    BaseMedia.objects.filter(notPublic=False).update(visibility='public')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gallery', '0009_basemedia_visibility'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_visibility),
+    ]

--- a/tkweb/apps/gallery/migrations/0011_remove_basemedia_notpublic.py
+++ b/tkweb/apps/gallery/migrations/0011_remove_basemedia_notpublic.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gallery', '0010_set_visibility'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='basemedia',
+            name='notPublic',
+        ),
+    ]

--- a/tkweb/apps/gallery/models.py
+++ b/tkweb/apps/gallery/models.py
@@ -70,6 +70,18 @@ class BaseMedia(models.Model):
         (AUDIO, 'Audio'),
         (OTHER, 'Other'),
     )
+
+    PUBLIC = 'public'
+    DISCARDED = 'discarded'
+    SENSITIVE = 'sensitive'
+    NEW = 'new'
+    VISIBILITY = (
+        (PUBLIC, 'Synligt'),
+        (DISCARDED, 'Skjult (fravalgt)'),
+        (SENSITIVE, 'Skjult (personfølsomt)'),
+        (NEW, 'Ubesluttet'),
+    )
+
     type = models.CharField(max_length=1,
                                       choices=TYPE_CHOICES,
                                       default=OTHER)
@@ -78,7 +90,8 @@ class BaseMedia(models.Model):
     album = models.ForeignKey(Album, on_delete=models.CASCADE, related_name='basemedia')
 
     date = models.DateTimeField(null=True, blank=True, verbose_name='Dato')
-    notPublic = models.BooleanField(default=False, verbose_name='Skjult')
+    visibility = models.CharField(max_length=10, choices=VISIBILITY,
+                                  verbose_name='Synlighed', default=NEW)
     caption = models.CharField(
         max_length=200, blank=True, verbose_name='Overskrift')
 
@@ -97,6 +110,10 @@ class BaseMedia(models.Model):
             return self.image.admin_thumbnail()
 
     admin_thumbnail.short_description = 'Thumbnail'
+
+    @property
+    def notPublic(self):
+        return self.visibility != self.PUBLIC
 
     def __str__(self):
         return '%s' % (self.slug)

--- a/tkweb/apps/gallery/static/gallery/tkgal-visibility.js
+++ b/tkweb/apps/gallery/static/gallery/tkgal-visibility.js
@@ -1,0 +1,8 @@
+$(document).keypress(function(ev) {
+	if (/^[1-9]$/.exec(ev.key)) {
+		var optionIndex = parseInt(ev.key);
+		var radios = $('#tkgal-container > *:not(.hidden) input[type=radio]');
+		var target = radios.eq(optionIndex - 1).val();
+		radios.val([target]);
+	}
+});

--- a/tkweb/apps/gallery/templates/album.html
+++ b/tkweb/apps/gallery/templates/album.html
@@ -17,6 +17,10 @@
 -->
 {% if edit_visibility_link %}
 <p><a href="{{ edit_visibility_link }}">BEST: Udvælg billeder</a></p>
+<p>{{ visible_count }} synlig{{ visible_count|pluralize:'e' }}
+og {{ hidden_count }} skjult{{ hidden_count|pluralize:'e' }}
+hvoraf {{ new_count }} er ny{{ new_count|pluralize:'e' }}.
+</p>
 {% endif %}
 <div class="row">
   <div class="col-xs-12 col-sm-7">

--- a/tkweb/apps/gallery/templates/album.html
+++ b/tkweb/apps/gallery/templates/album.html
@@ -15,6 +15,9 @@
 {% for file in files %}https://{{ request.get_host }}{{ file.file.url }}
 {% endfor %}
 -->
+{% if edit_visibility_link %}
+<p><a href="{{ edit_visibility_link }}">BEST: Udvælg billeder</a></p>
+{% endif %}
 <div class="row">
   <div class="col-xs-12 col-sm-7">
     <ol class="breadcrumb imagetitle">

--- a/tkweb/apps/gallery/templates/image.html
+++ b/tkweb/apps/gallery/templates/image.html
@@ -9,6 +9,9 @@
 {% block js %}
   <script src="{% static "gallery/jquery.touchswipe.min.js" %}"></script>
   <script src="{% static "gallery/tkgal.js" %}"></script>
+  {% if edit_visibility %}
+  <script src="{% static "gallery/tkgal-visibility.js" %}"></script>
+  {% endif %}
 {% endblock js %}
 
 {% block canonical_url %}{% url 'image' gfyear=album.gfyear album_slug=album.slug image_slug=start_file.slug %}{% endblock canonical_url %}
@@ -20,6 +23,9 @@
 {% endblock opengraph %}
 
 {% block raw_content %}
+{% if edit_visibility %}
+<form id="tkgal-form" style="height: 100%" method="post" action="{% url 'set_image_visibility' %}">{% csrf_token %}
+{% endif %}
 <div id="tkgal-container" role="main">
 	{% for file, next_file, prev_file in file_orders %}
 	<div class="{% if file != start_file %}hidden{% endif %}" data-permlink="{{ file.slug }}">
@@ -66,6 +72,10 @@
 					<li><a id="albumlink" href="{% url 'album' gfyear=album.gfyear album_slug=album.slug %}">{{ album.title }}</a></li>
 					<li>{{ forloop.counter }} af {{ file_count }}{% if file.type == "I" %} <span class="hidden-xs">billede{{ file_count|pluralize:"r" }}</span>{% endif %}</li>
 				</ol>
+                                {% if edit_visibility %}
+		{{ file.visibility_field }}
+                <input type="submit" name="r{{ file.pk }}" value="Gem album" style="background-color: transparent"/>
+{% endif %}
 			</div>
 			<div class="overlay overlay-bottom">
 				<div class="row">
@@ -87,6 +97,7 @@
 	</div>
 	{% endfor %}
 </div>
+{% if edit_visibility %}</form>{% endif %}
 
 <div class="container">
     <div id="tkgal-caption-container">

--- a/tkweb/apps/gallery/urls.py
+++ b/tkweb/apps/gallery/urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
         tkweb.apps.gallery.views.image,
         name='image'),
 
+    # Single images
+    url(r'^set_visibility/$',
+        tkweb.apps.gallery.views.set_visibility,
+        name='set_image_visibility'),
+
     # JFU upload
     url(r'^upload/',
         tkweb.apps.gallery.views.upload,

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -99,6 +99,19 @@ def album(request, gfyear, album_slug):
                       image_slug=file.slug)
         context['edit_visibility_link'] = (
             reverse('image', kwargs=kwargs) + '?v=1')
+
+        qs = album.basemedia.all().order_by()
+        qs_visibility = qs.values_list('visibility')
+        visibility_counts = dict(qs_visibility.annotate(count=Count('pk')))
+        c_public = visibility_counts.pop(BaseMedia.PUBLIC, 0)
+        c_discarded = visibility_counts.pop(BaseMedia.DISCARDED, 0)
+        c_sensitive = visibility_counts.pop(BaseMedia.SENSITIVE, 0)
+        c_new = visibility_counts.pop(BaseMedia.NEW, 0)
+        if visibility_counts:
+            raise ValueError(visibility_counts)
+        context['visible_count'] = c_public
+        context['hidden_count'] = c_discarded + c_sensitive + c_new
+        context['new_count'] = c_new
     return render(request, 'album.html', context)
 
 

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -53,10 +53,10 @@ def album(request, gfyear, album_slug):
                'files': files}
 
     edit_visibility = request.user.has_perms('gallery.change_image')
-    file = album.basemedia.first()
-    if edit_visibility and file:
+    new_file = album.basemedia.filter(visibility=BaseMedia.NEW).first()
+    if edit_visibility and new_file:
         kwargs = dict(gfyear=album.gfyear, album_slug=album.slug,
-                      image_slug=file.slug)
+                      image_slug=new_file.slug)
         context['edit_visibility_link'] = (
             reverse('image', kwargs=kwargs) + '?v=1')
 

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -51,7 +51,7 @@ def image(request, gfyear, album_slug, image_slug, **kwargs):
     album = get_object_or_404(Album, gfyear=gfyear, slug=album_slug)
 
     # list() will force evaluation of the QuerySet. It is now iterable.
-    files = list(album.basemedia.exclude(notPublic=True).select_subclasses())
+    files = list(album.basemedia.filter(visibility=BaseMedia.PUBLIC).select_subclasses())
     start_file = album.basemedia.filter(album=album, slug=image_slug).select_subclasses().first()
 
     if not start_file:

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -33,9 +33,10 @@ def gallery(request, **kwargs):
     albums = allalbums.filter(gfyear__exact=show_year)
     albums = albums.annotate(count=Count('basemedia'))
 
-    firstImages = BaseMedia.objects.filter(album__in=albums, isCoverFile=True).prefetch_related('album').select_subclasses()
-    firstImages = {fi.album: fi for fi in firstImages}
-    albumSets = [(a, firstImages.get(a)) for a in albums]
+    firstImages = BaseMedia.objects.filter(album__in=albums, isCoverFile=True)
+    firstImages = firstImages.select_subclasses()
+    firstImages = {fi.album_id: fi for fi in firstImages}
+    albumSets = [(a, firstImages.get(a.id)) for a in albums]
 
     context = {'years': years,
                'show_year': show_year,

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals, division
 
 import os
-import re
 
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import ValidationError
@@ -10,54 +9,12 @@ from django.core.urlresolvers import reverse
 from django.db.models import Count
 from django.http import (
     Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect)
-from django import forms
 from django.shortcuts import get_object_or_404
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
 from jfu.http import upload_receive, UploadResponse, JFUResponse
 from tkweb.apps.gallery.models import Album, BaseMedia, Image, GenericFile
-
-
-class EditVisibilityForm(forms.Form):
-    class Missing(Exception):
-        pass
-
-    def __init__(self, file_visibility, **kwargs):
-        super(EditVisibilityForm, self).__init__(**kwargs)
-        self.basemedias = []
-        self.album_pks = set()
-        for file in file_visibility:
-            if isinstance(file, BaseMedia):
-                pk = file.pk
-                visibility = file.visibility
-                album = file.album_id
-            elif isinstance(file, tuple):
-                pk, visibility, album = file
-            else:
-                raise TypeError(type(file))
-            k = 'i%s' % pk
-            self.album_pks.add(album)
-            self.fields[k] = forms.ChoiceField(
-                choices=BaseMedia.VISIBILITY,
-                initial=visibility,
-                widget=forms.RadioSelect)
-            self.basemedias.append((pk, k))
-
-    @classmethod
-    def from_POST(cls, post_data):
-        pattern = r'^i(\d+)$'
-        pks = []
-        for k, v in post_data.items():
-            mo = re.match(pattern, k)
-            if mo:
-                pks.append(int(mo.group(1)))
-        files = BaseMedia.objects.filter(pk__in=pks)
-        files = list(files.values_list('pk', 'visibility', 'album_id'))
-        found_pks = [f[0] for f in files]
-        missing = set(pks) - set(found_pks)
-        if missing:
-            raise cls.Missing('Not found: %r' % (sorted(missing),))
-        return cls(files, data=post_data)
+from tkweb.apps.gallery.forms import EditVisibilityForm
 
 
 def gallery(request, **kwargs):

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -18,7 +18,8 @@ from tkweb.apps.gallery.forms import EditVisibilityForm
 
 
 def gallery(request, **kwargs):
-    allalbums = Album.objects.exclude(basemedia__isnull=True)
+    allalbums = Album.objects.filter(basemedia__visibility=BaseMedia.PUBLIC)
+    allalbums = allalbums.exclude(basemedia__isnull=True)
     # Without order_by(), distinct() still returns duplicate gfyears.
     years = allalbums.order_by().values_list('gfyear', flat=True).distinct()
     years = sorted(years, reverse=True)

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -1,16 +1,63 @@
 # encoding: utf8
 from __future__ import absolute_import, unicode_literals, division
 
+import os
+import re
+
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
 from django.db.models import Count
-from django.http import Http404
+from django.http import (
+    Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect)
+from django import forms
 from django.shortcuts import get_object_or_404
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
 from jfu.http import upload_receive, UploadResponse, JFUResponse
 from tkweb.apps.gallery.models import Album, BaseMedia, Image, GenericFile
-import os
+
+
+class EditVisibilityForm(forms.Form):
+    class Missing(Exception):
+        pass
+
+    def __init__(self, file_visibility, **kwargs):
+        super(EditVisibilityForm, self).__init__(**kwargs)
+        self.basemedias = []
+        self.album_pks = set()
+        for file in file_visibility:
+            if isinstance(file, BaseMedia):
+                pk = file.pk
+                visibility = file.visibility
+                album = file.album_id
+            elif isinstance(file, tuple):
+                pk, visibility, album = file
+            else:
+                raise TypeError(type(file))
+            k = 'i%s' % pk
+            self.album_pks.add(album)
+            self.fields[k] = forms.ChoiceField(
+                choices=BaseMedia.VISIBILITY,
+                initial=visibility,
+                widget=forms.RadioSelect)
+            self.basemedias.append((pk, k))
+
+    @classmethod
+    def from_POST(cls, post_data):
+        pattern = r'^i(\d+)$'
+        pks = []
+        for k, v in post_data.items():
+            mo = re.match(pattern, k)
+            if mo:
+                pks.append(int(mo.group(1)))
+        files = BaseMedia.objects.filter(pk__in=pks)
+        files = list(files.values_list('pk', 'visibility', 'album_id'))
+        found_pks = [f[0] for f in files]
+        missing = set(pks) - set(found_pks)
+        if missing:
+            raise cls.Missing('Not found: %r' % (sorted(missing),))
+        return cls(files, data=post_data)
 
 
 def gallery(request, **kwargs):
@@ -44,20 +91,39 @@ def album(request, gfyear, album_slug):
     files = album.basemedia.filter(visibility=BaseMedia.PUBLIC).select_subclasses()
     context = {'album': album,
                'files': files}
+
+    edit_visibility = request.user.has_perms('gallery.change_image')
+    file = album.basemedia.first()
+    if edit_visibility and file:
+        kwargs = dict(gfyear=album.gfyear, album_slug=album.slug,
+                      image_slug=file.slug)
+        context['edit_visibility_link'] = (
+            reverse('image', kwargs=kwargs) + '?v=1')
     return render(request, 'album.html', context)
 
 
 def image(request, gfyear, album_slug, image_slug, **kwargs):
     album = get_object_or_404(Album, gfyear=gfyear, slug=album_slug)
 
+    edit_visibility = (bool(request.GET.get('v')) and
+                       request.user.has_perms('gallery.change_image'))
+
+    qs = album.basemedia.all()
+    if not edit_visibility:
+        qs = qs.filter(visibility=BaseMedia.PUBLIC)
+    qs = qs.select_subclasses()
     # list() will force evaluation of the QuerySet. It is now iterable.
-    files = list(album.basemedia.filter(visibility=BaseMedia.PUBLIC).select_subclasses())
+    files = list(qs)
+    form = EditVisibilityForm(files)
     start_file = album.basemedia.filter(album=album, slug=image_slug).select_subclasses().first()
+    if edit_visibility:
+        for file, (pk, key) in zip(files, form.basemedias):
+            file.visibility_field = form[key]
 
     if not start_file:
         raise Http404("Billedet kan ikke findes")
 
-    if start_file.notPublic:
+    if start_file.notPublic and not edit_visibility:
         raise Http404("Billedet kan ikke findes")
 
     prev_files = files[1:]+files[:1]
@@ -70,6 +136,7 @@ def image(request, gfyear, album_slug, image_slug, **kwargs):
         'file_orders': file_orders,
         'start_file': start_file,
         'file_count': file_count,
+        'edit_visibility': edit_visibility,
     }
     return render(request, 'image.html', context)
 
@@ -132,3 +199,32 @@ def upload_delete(request, pk):
         success = False
 
     return JFUResponse(request, success)
+
+
+@require_POST
+@permission_required('gallery.change_image', raise_exception=True)
+def set_visibility(request):
+    try:
+        form = EditVisibilityForm.from_POST(request.POST)
+    except EditVisibilityForm.Missing as exn:
+        return HttpResponseBadRequest(str(exn))
+    if not form.is_valid():
+        return HttpResponseBadRequest(str(form.errors))
+    for pk, key in form.basemedias:
+        initial = form.fields[key].initial
+        value = form.cleaned_data[key]
+        if initial != value:
+            BaseMedia.objects.filter(pk=pk).update(visibility=value)
+
+    albums = list(Album.objects.filter(pk__in=form.album_pks))
+    for a in albums:
+        # Update isCoverFile
+        a.clean()
+
+    # Redirect to album
+    if albums:
+        album = albums[0]
+        kwargs = dict(gfyear=album.gfyear, album_slug=album.slug)
+        return HttpResponseRedirect(reverse('album', kwargs=kwargs))
+    else:
+        return HttpResponse('Synlighed på givne billeder er blevet opdateret')

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -30,7 +30,8 @@ def gallery(request, **kwargs):
     show_year = kwargs.get('gfyear', latest_year)
     show_year = int(show_year) if show_year else None
 
-    albums = allalbums.filter(gfyear__exact=show_year).prefetch_related('basemedia').annotate(count=Count('basemedia'))
+    albums = allalbums.filter(gfyear__exact=show_year)
+    albums = albums.annotate(count=Count('basemedia'))
 
     firstImages = BaseMedia.objects.filter(album__in=albums, isCoverFile=True).prefetch_related('album').select_subclasses()
     firstImages = {fi.album: fi for fi in firstImages}

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -41,7 +41,7 @@ def gallery(request, **kwargs):
 
 def album(request, gfyear, album_slug):
     album = get_object_or_404(Album, gfyear=gfyear, slug=album_slug)
-    files = album.basemedia.exclude(notPublic=True).select_subclasses()
+    files = album.basemedia.filter(visibility=BaseMedia.PUBLIC).select_subclasses()
     context = {'album': album,
                'files': files}
     return render(request, 'album.html', context)


### PR DESCRIPTION
Her er et bud på en implementation af #98. Hvad synes I, @neic og @martinsand?

* Tilføj link "BEST: Udvælg billeder" på album-siden for folk med rettigheden `gallery.change_image`
* Linket går til /år/album/første-billede?v=1, hvor "v=1" er en markør der viser *alle* (inkl. skjulte) billeder og tilføjer en formular
* Man kan trykke 1, 2, 3 eller 4 på tastaturet for at vælge mellem de fire valgmuligheder "Synligt", "Skjult (fravalgt)", "Skjult (personfølsomt)", "Ubesluttet"; typisk vil man trykke 1 eller 2 og så højre-pil for at gå videre.
* Billeder der var skjulte førhen (notPublic=True) bliver sat til "Skjult (fravalgt)".
* I modellen er default synlighed "Ubesluttet", så billeder uploadet via admin-interface bliver først vist når man har markeret dem "synlige".

![screenshot from 2017-03-31 14-53-28](https://cloud.githubusercontent.com/assets/373639/24565121/db98fd86-1621-11e7-9c98-a1c7eba6ff92.png)
![screenshot from 2017-03-31 15-13-32](https://cloud.githubusercontent.com/assets/373639/24565771/a8937f1c-1624-11e7-8dae-15009e845f46.png)
![screenshot from 2017-03-31 14-50-02](https://cloud.githubusercontent.com/assets/373639/24565123/de440d6e-1621-11e7-83b0-1a3c1785da69.png)
