### PR TITLE
Add try-imports in base.py for regnskab, mediumeditor, and uniprint

### DIFF
--- a/tkweb/settings/base.py
+++ b/tkweb/settings/base.py
@@ -43,6 +43,33 @@ LOCAL_APPS = [
     'tkweb.apps.scripts',
 ]
 
+try:
+    # Is git+https://github.com/TK-IT/regnskab.git installed?
+    import regnskab
+except ImportError:
+    pass
+else:
+    LOCAL_APPS.append('regnskab')
+    LOCAL_APPS.append('krydsliste')
+    TKWEB_IDM_MODULE = 'tkweb.apps.idm'
+
+    try:
+        # Is django-mediumeditor installed?
+        import mediumeditor
+    except ImportError:
+        USE_MEDIUM_EDITOR = False
+    else:
+        USE_MEDIUM_EDITOR = True
+        THIRD_PARTY_APPS.append('mediumeditor')
+
+try:
+    # Is git+https://github.com/TK-IT/uniprint.git installed?
+    import uniprint
+except ImportError:
+    pass
+else:
+    LOCAL_APPS.append('uniprint')
+
 INSTALLED_APPS = DEFAULT_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 


### PR DESCRIPTION
In a dev environment, we want these apps to be automatically added to
INSTALLED_APPS when they are available.