### PR TITLE
Uniprint: Add "tk-" prefix to username on printer

### DIFF
--- a/tkweb/settings/base.py
+++ b/tkweb/settings/base.py
@@ -248,3 +248,8 @@ WIKI_MARKDOWN_KWARGS = {
         'markdown.extensions.admonition',
     ],
 }
+
+# Uniprint
+# --------
+
+PRINT_USERNAME_PREFIX = "tk-"


### PR DESCRIPTION
Also set username to "unknown" in case no user is supplied. This avoids
using whatever is the system default in that case.