### PR TITLE
Check for korrupte billeder ved upload

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,6 @@
         <div class="jumbotron">
             <h1>{{ status|default:"404 Not Found" }}</h1>
             <h2>Gå et skridt tilbage og bund en bajer!</h2>
-            <p>{{ explanation|default:"" }}</p>
         </div>
     </div>
     <div class="col-xs-12 col-sm-offset-1 col-sm-10 col-lg-offset-2 col-lg-8">

--- a/tkweb/apps/gallery/models.py
+++ b/tkweb/apps/gallery/models.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals, division
 
 from datetime import date
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from django.dispatch import receiver
@@ -160,6 +161,29 @@ class Image(BaseMedia):
             else:
                 self.slug = self.date.strftime('%Y%m%d%H%M%S_%f')[:len("YYYYmmddHHMMSS_ff")]
 
+    def save(self, *args, **kwargs):
+        """
+        This saves the Image, tries to prewarm VersatileImageField and deletes
+        itself again if it fails. Ideally this would be done in clean(), but
+        VersatileImageField cannot prewarm before it is saved and does not have
+        a clean that checks if the warming is bound to succeed.
+
+        """
+        super().save(*args, **kwargs)
+        image_warmer = VersatileImageFieldWarmer(
+            instance_or_queryset=self, rendition_key_set="gallery", image_attr="file"
+        )
+
+        num_created, failed_to_create = image_warmer.warm()
+        if failed_to_create:
+
+            self.delete()  # Hey! Look at me!
+
+            logger.warning(
+                "Prewarming during save() of %s failed. Deleting again." % self
+            )
+            raise ValidationError("Corrupt image. Deleting")
+
 
 class GenericFile(BaseMedia):
     class Meta:
@@ -188,19 +212,6 @@ class GenericFile(BaseMedia):
 def cleanAlbum(sender, instance, **kwargs):
     if instance.isCoverFile is None:
         instance.album.full_clean()
-
-
-@receiver(models.signals.post_save, sender=Image)
-def generateImageThumbnails(sender, instance, **kwargs):
-    image_warmer = VersatileImageFieldWarmer(
-        instance_or_queryset=instance,
-        rendition_key_set='gallery',
-        image_attr='file',
-    )
-
-    num_created, failed_to_create = image_warmer.warm()
-    logger.debug('generateImageThumbnails: %d thumbnails created. Missing %s' % (
-                 num_created, failed_to_create))
 
 
 @receiver(models.signals.post_delete, sender=Image)

--- a/tkweb/apps/gallery/tests.py
+++ b/tkweb/apps/gallery/tests.py
@@ -1,0 +1,46 @@
+from PIL import Image as PILImage
+from django.core.exceptions import ValidationError
+from django.test import TestCase, override_settings
+from tkweb.apps.gallery.models import Album, Image
+import tempfile
+
+
+class SimpleAlbumTest(TestCase):
+    def test_empty_album(self):
+        self.assertFalse(Album.objects.exists())
+        instance = Album.objects.create(title="Album Title", slug="album-title")
+        instance.full_clean()
+        self.assertTrue(Album.objects.exists())
+
+
+@override_settings(MEDIA_ROOT=tempfile.gettempdir())
+class SimpleMediaTest(TestCase):
+    def setUp(self):
+        album = Album.objects.create(title="Album Title", slug="album-title")
+        album.full_clean()
+
+    def generate_image(self, suffix):
+        album = Album.objects.all()[0]
+
+        temp_file = tempfile.NamedTemporaryFile(suffix=suffix)
+        PILImage.new("RGB", (100, 100)).save(temp_file)
+
+        Image(file=temp_file.name, album=album).save()
+
+        try:
+            Image.objects.all()[0].file.crop["200x200"]
+        except ValidationError:
+            self.fail(
+                "VersatileImageField Raised ValidationError on a good %s image" % suffix
+            )
+        self.assertEqual(len(Image.objects.all()), 1)
+        self.assertIsInstance(album.basemedia.select_subclasses()[0], Image)
+
+    def test_simple_jpg_album(self):
+        self.generate_image(".jpg")
+
+    def test_simple_png_album(self):
+        self.generate_image(".png")
+
+    def test_simple_gif_album(self):
+        self.generate_image(".gif")

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -15,9 +15,7 @@ from jfu.http import upload_receive, UploadResponse, JFUResponse
 from tkweb.apps.gallery.models import Album, BaseMedia, Image, GenericFile
 from tkweb.apps.gallery.forms import EditVisibilityForm
 import os
-import logging
 
-logger = logging.getLogger(__name__)
 
 GALLERY_PERMISSION = 'gallery.change_image'
 
@@ -104,15 +102,7 @@ def album(request, gfyear, album_slug):
         context['visible_count'] = c_public
         context['hidden_count'] = c_discarded + c_sensitive + c_delete + c_new
         context['new_count'] = c_new
-    try:
-        r = render(request, 'album.html', context)
-    except OSError as exn:
-        logger.error('OSError: %s at %s' % (exn, request.path))
-        context = {'status': '500 Internal Server Error',
-                   'explanation': 'Dette album kan ikke vises, da en eller flere af de tilføjede filer er beskadiget.'}
-        r = render(request, '404.html', context)
-        r.status_code = 500
-    return r
+    return render(request, 'album.html', context)
 
 
 def image(request, gfyear, album_slug, image_slug, **kwargs):

--- a/tkweb/apps/gallery/views.py
+++ b/tkweb/apps/gallery/views.py
@@ -175,6 +175,7 @@ def upload(request):
 
     try:
         instance.full_clean()
+        instance.save()
     except ValidationError as exn:
         try:
             error = ' '.join(
@@ -191,7 +192,6 @@ def upload(request):
         }
         return UploadResponse(request, jfu_msg)
 
-    instance.save()
     jfu_msg = {
         'name': os.path.basename(instance.file.path),
         'size': file.size,


### PR DESCRIPTION
Jeg er ikke sikker på det her er en god ide. Det havde været lækkert hvis VersatileImageField havde en `clean()`. Måske skal vi lave et PR der til istedet. Hvad sider @Mortal?