### PR TITLE
Don't use pipenv in cron script

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -3,5 +3,5 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd "$DIR" || exit
 
-pipenv run ./manage.py updateical --settings=tkweb.settings.prod
-pipenv run ./manage.py delete_marked_images --settings=tkweb.settings.prod
+.venv/bin/python ./manage.py updateical --settings=tkweb.settings.prod
+.venv/bin/python ./manage.py delete_marked_images --settings=tkweb.settings.prod


### PR DESCRIPTION
Since pipenv is not installed on the system $PATH, and pipenv uses click
which requires a non-ASCII locale, it is quite a bother to use pipenv in
a crontab. Just use the standard virtualenv location instead to locate
the Python interpreter.