### PR TITLE
Display 'caption' as mouse-over text in gallery

### DIFF
--- a/tkweb/apps/gallery/templates/image.html
+++ b/tkweb/apps/gallery/templates/image.html
@@ -51,6 +51,7 @@
 				src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
 				{% else %}
 				src="{{ file.file.thumbnail.720x720.url }}"
+				title="{{ file.caption }}"
 				{% endif %}>
 		{% elif file.type == "A" %}
 			<audio controls

--- a/tkweb/apps/gallery/templates/image.html
+++ b/tkweb/apps/gallery/templates/image.html
@@ -51,8 +51,8 @@
 				src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
 				{% else %}
 				src="{{ file.file.thumbnail.720x720.url }}"
-				title="{{ file.caption }}"
-				{% endif %}>
+				{% endif %}
+				title="{{ file.caption }}">
 		{% elif file.type == "A" %}
 			<audio controls
 				{% if file != start_file %}data-{% endif %}src=


### PR DESCRIPTION
'caption'-feltet ser ikke ud til at blive brugt, det kunne være sjovt at have som mouse-over-tekst. Specifik anvendelse for mig er muligheden for xkcd-agtig mouse-over i løbeseddelsgalleriet.