### PR TITLE
Stilisér RemToR med straightepsilon

### DIFF
--- a/tkweb/apps/eval/evalmacros.py
+++ b/tkweb/apps/eval/evalmacros.py
@@ -243,19 +243,19 @@ class EvalMacroPattern(markdown.inlinepatterns.Pattern):
     }
 
     def remtor(self, full=''):
-        return self.markdown.htmlStash.store('R&epsilon;mToR')
+        return self.markdown.htmlStash.store('R&straightepsilon;mToR')
 
     def eps(self, full=''):
-        return self.markdown.htmlStash.store('&epsilon;')
+        return self.markdown.htmlStash.store('&straightepsilon;')
 
     remtor.meta = {
-        'short_description': 'R&epsilon;mToR',
+        'short_description': 'R&straightepsilon;mToR',
         'help_text': (
-            'Brug følgende makroer til at skrive R&epsilon;mToR.' +
+            'Brug følgende makroer til at skrive R&straightepsilon;mToR.' +
             '<table class="table table-condensed">' +
             '<tr><th>Makro</th><th>Output</th></tr>' +
-            '<tr><td>[remtor]</td><td>R&epsilon;mToR</td></tr>' +
-            '<tr><td>[eps]</td><td>&epsilon;</td></tr>' +
+            '<tr><td>[remtor]</td><td>R&straightepsilon;mToR</td></tr>' +
+            '<tr><td>[eps]</td><td>&straightepsilon;</td></tr>' +
             '</table>'),
     }
 


### PR DESCRIPTION
"Epsilon"et (som egentlig er et "element i"-tegn) på RemToR ligner mere tegnet, der fremkommer ved `&straightepsilon;` end det nuværende `&epsilon;`

Signed-off-by: Søren Dyhr <siadyhr@gmail.com>