### PR TITLE
Change the maillist header name of Hængerlisten

### DIFF
--- a/tkweb/apps/mailinglist/views.py
+++ b/tkweb/apps/mailinglist/views.py
@@ -68,7 +68,7 @@ class EmailFormView(FormView):
 
         sender = from_email
         list_requests = 'admin@TAAGEKAMMERET.dk'
-        list_name = 'mailinglist'
+        list_name = 'haengerlisten'
         list_id = '%s.TAAGEKAMMERET.dk' % list_name
         unsub = '<mailto:%s?subject=unsubscribe%%20%s>' % (list_requests, list_name)
         help = '<mailto:%s?subject=list-help>' % (list_requests,)

--- a/tkweb/apps/mailinglist/views.py
+++ b/tkweb/apps/mailinglist/views.py
@@ -68,11 +68,10 @@ class EmailFormView(FormView):
 
         sender = from_email
         list_requests = 'admin@TAAGEKAMMERET.dk'
-        list_name = 'haengerlisten'
-        list_id = '%s.TAAGEKAMMERET.dk' % list_name
-        unsub = '<mailto:%s?subject=unsubscribe%%20%s>' % (list_requests, list_name)
+        list_id = 'mailinglist.TAAGEKAMMERET.dk'
+        unsub = '<mailto:%s?subject=unsubscribe%%20haengerlisten>' % (list_requests,)
         help = '<mailto:%s?subject=list-help>' % (list_requests,)
-        sub = '<mailto:%s?subject=subscribe%%20%s>' % (list_requests, list_name)
+        sub = '<mailto:%s?subject=subscribe%%20haengerlisten>' % (list_requests,)
 
         messages = []
         for recipient in recipients:


### PR DESCRIPTION
Currently, the list_name of Hængerlisten is just `mailinglist`. This PR changes that to `haengerlisten`, which will make it more clear whenever an unsubscribe request is received that this was specifically triggered by an email sent to Hængerlisten rather then some of our other mailing lists.

I dared not to actually put `hængerlisten` as list_name, as non-ascii in email headers scares me.

Note: This change is untested. However, I don't believe anything depends on the name specifically being `mailinglist`.